### PR TITLE
Fix handling of quotation marks in key value reader

### DIFF
--- a/lib/rakeoe/key_value_reader.rb
+++ b/lib/rakeoe/key_value_reader.rb
@@ -74,19 +74,21 @@ class KeyValueReader
       key.gsub!(/["']*/, '')
       key.strip!
 
-      unless value.empty?
-        prev_key = key
-        # We could have split multiple '=' in one line.
-        # Put back any "=" in the value part
-        # and concatenate split strings
-        val = value.join('=')
-        val.gsub!(/["'\n]*/, '')
-        env[key] = val.strip
-      else
+      if value.empty?
         if prev_key && !line.include?('=')
           # multiline value: treat key as value and add to previous found key
           env[prev_key] = "#{env[prev_key]} #{key}"
         end
+      else
+        prev_key = key
+        # We could have split multiple '=' in one line.
+        # Put back any "=" in the value part
+        # and concatenate split strings
+        val = value.join('=').strip
+        val.gsub!(/^["']*/, '')
+        val.gsub!(/["']$/, '')
+        val.gsub!(/[\n]*/, '')
+        env[key] = val.strip
       end
 
     end


### PR DESCRIPTION
This fixes #13. If a Key value pair contains quotation marks theses are removed.
the proposed fix only removes quotation marks at the beginning and the end
of the value part.
