### PR TITLE
Update toolchain.rb to fix handling of objcopy on mingw

### DIFF
--- a/lib/rakeoe/toolchain.rb
+++ b/lib/rakeoe/toolchain.rb
@@ -469,7 +469,10 @@ class Toolchain
 
     sh "#{@settings['SIZE']} #{objs} >#{params[:app]}.size" if @settings['SIZE']
     sh "#{@settings['CXX']} #{incs} #{objs} #{ldflags} #{libs} -o #{params[:app]} -Wl,-Map,#{params[:app]}.map"
-    sh "#{@settings['OBJCOPY']} -O binary #{params[:app]} #{params[:app]}.bin"
+    if RbConfig::CONFIG["host_os"] != "mingw32"
+      sh "#{@settings['OBJCOPY']} -O binary #{params[:app]} #{params[:app]}.bin"
+    end
+      
   end
 
   # Creates test


### PR DESCRIPTION
**!!! untested proposal !!!**
This may fix Issue #22 by omitting the objcopy part. On the other hand it may fails again on mingw64
